### PR TITLE
use sha256 hash for current swarm-client release

### DIFF
--- a/Formula/swarm-client.rb
+++ b/Formula/swarm-client.rb
@@ -2,9 +2,9 @@ require "formula"
 
 class SwarmClient < Formula
   homepage "https://giantswarm.io"
-  # openssl dgst -sha1 <file>
+  # openssl dgst -sha256 <file>
   url "https://downloads.giantswarm.io/swarm/clients/0.27.0/swarm-0.27.0-darwin-amd64.tar.gz"
-  sha1 "7432927c2609cc9edeac912123b468f9d055cbf1"
+  sha256 "3defc4bac2f7e64b299b87a7a7199e855f65ce0f1e2943f390e047310ade9c47"
   version "0.27.0"
 
   def install


### PR DESCRIPTION
https://github.com/giantswarm/homebrew-swarm/pull/4#issuecomment-208467725
