### PR TITLE
Change download URL

### DIFF
--- a/Formula/gsctl.rb
+++ b/Formula/gsctl.rb
@@ -6,7 +6,7 @@ require "formula"
 class Gsctl < Formula
   desc "Controls things on Giant Swarm"
   homepage "https://github.com/giantswarm/gsctl"
-  url "http://downloads.giantswarm.io/gsctl/0.14.4/gsctl-0.14.4-darwin-amd64.tar.gz"
+  url "https://github.com/giantswarm/gsctl/releases/download/0.14.4/gsctl-0.14.4-darwin-amd64.tar.gz"
   version "0.14.4"
   # openssl dgst -sha256 <file>
   sha256 "63b2ae80c09d97eb19f04eb7afdb1bdd54fed3d49a3039d052bf5aa0258339fd"


### PR DESCRIPTION
This sets the download URL for the latest gsctl release to the one published in the Github release. From all I can find, homebrew should be able to use that URL.